### PR TITLE
feat(scripting/lua): implement SetInterval

### DIFF
--- a/code/components/citizen-scripting-lua/src/LuaScriptRuntime.cpp
+++ b/code/components/citizen-scripting-lua/src/LuaScriptRuntime.cpp
@@ -1081,8 +1081,18 @@ static int Lua_CreateThreadNow(lua_State* L)
 
 static int Lua_SetTimeout(lua_State* L)
 {
-	auto timeout = (int)luaL_checknumber(L, 1);
-	return Lua_CreateThreadInternal(L, false, timeout, 2);
+	if (lua_isfunction(L, 2))
+	{
+		auto timeout = (int)luaL_checknumber(L, 1);
+		return Lua_CreateThreadInternal(L, false, timeout, 2);
+	}
+	else if (lua_isfunction(L, 1))
+	{
+		auto timeout = (int)luaL_checknumber(L, 2);
+		return Lua_CreateThreadInternal(L, false, timeout, 1);
+	}
+
+	return luaL_error(L, "'SetTimeout' expects a number and function as arguments. Received %s and %s.", luaL_typename(L, 1), luaL_typename(L, 2));
 }
 
 static const struct luaL_Reg g_citizenLib[] = {


### PR DESCRIPTION
Pulled the last request down due to implementation of tickless resources. Still just a convenient wrapper as it was, and maybe the type checking is excessive. Should be 1:1 with the v8 setInterval function, though we can send the id back as an argument to alter the yield time.

I used `CreateThreadNow` so we could immediately return the runtime reference id instead of counting up in Lua.

```lua
local t = Citizen.SetInterval(function(...)
	GetEntityCoords(...)
end, 0, PlayerPedId())

Citizen.SetInterval(t, 500)

Citizen.ClearInterval(t)
```